### PR TITLE
Fix typo in utils docstring

### DIFF
--- a/src/superpathlib/utils.py
+++ b/src/superpathlib/utils.py
@@ -4,8 +4,8 @@ from collections.abc import Callable
 def find_first_match(condition: Callable[..., bool]) -> int:
     """
     :param condition: Condition that number needs to match.
-                      The condition is assumed to be valid for all integers staring
-                      from an initial value.
+                     The condition is assumed to be valid for all integers starting
+                     from an initial value.
     :return: First integer for which condition is valid.
     """
 


### PR DESCRIPTION
## Summary
- fix a typo in the `find_first_match` docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'simple_classproperty')*

------
https://chatgpt.com/codex/tasks/task_e_6848c5f048808323b9739ecc04399502